### PR TITLE
Added instructions for installing different versions with the source code

### DIFF
--- a/docs-2.0/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
+++ b/docs-2.0/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
@@ -41,9 +41,9 @@ Installing Nebula Graph from the source code allows you to customize the compili
     > **NOTE**:
     >
     >* The installation path is `/user/local/nebula` by default. To customize it, add the `-DCMAKE_INSTALL_PREFIX=/your/install/path/` CMake variable in the following command.
-    >* For more information on CMake variables, see [CMake variables](#cmake-variables).
+    >* For more information about CMake variables, see [CMake variables](#cmake-variables).
 
-   * If you are installing  the latest version of Nebula Graph 2.x and has cloned the `master` branch in step 1, run the following command.
+   * If you are installing the latest version of Nebula Graph 2.x and has cloned the `master` branch in step 1, run the following command.
 
         ```bash
         $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ..

--- a/docs-2.0/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
+++ b/docs-2.0/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
@@ -12,15 +12,17 @@ Installing Nebula Graph from the source code allows you to customize the compili
 
 1. Use Git to clone the source code of Nebula Graph to your host.
 
-    ```bash
-    $ git clone https://github.com/vesoft-inc/nebula-graph.git
-    ```
+    * To install the latest version of Nebula Graph 2.x, run the following command to download the source code from the `master` branch.
 
-    The source code of Nebula Graph versions like 2.0.0-alpha or 2.0.0-beta is stored in particular branches. You can use the `--branch` or `-b` option to specify the branch to be cloned. For example, for 2.0.0-alpha, run the following command.
+        ```bash
+        $ git clone https://github.com/vesoft-inc/nebula-graph.git
+        ```
 
-    ```bash
-    $ git clone --branch v2.0.0-alpha https://github.com/vesoft-inc/nebula-graph.git
-    ```
+    * To install a specific version of Nebula Graph 2.x, use the `--branch <branch_name>` option to specify the correct branch. For example, to install 2.0.0 beta, run the following command.
+
+        ```bash
+        $ git clone --branch v2.0.0-beta https://github.com/vesoft-inc/nebula-graph.git
+        ```
 
 2. Make the `nebula-graph` directory the current working directory.
 
@@ -39,11 +41,20 @@ Installing Nebula Graph from the source code allows you to customize the compili
     > **NOTE**:
     >
     >* The installation path is `/user/local/nebula` by default. To customize it, add the `-DCMAKE_INSTALL_PREFIX=/your/install/path/` CMake variable in the following command.
-    >* For more information about CMake variables, see [CMake variables](#cmake-variables).
+    >* For more information on CMake variables, see [CMake variables](#cmake-variables).
 
-    ```bash
-    $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ..
-    ```
+   * If you are installing  the latest version of Nebula Graph 2.x and has cloned the `master` branch in step 1, run the following command.
+
+        ```bash
+        $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ..
+        ```
+
+   * If you are installing a specific version of Nebula Graph 2.x and has cloned the corresponding branch in step 1, use the `-DNEBULA_COMMON_REPO_TAG` and `-DNEBULA_STORAGE_REPO_TAG` options to specify the correct branches of the [nebula-common](https://github.com/vesoft-inc/nebula-common "GitHub page of the nebula-common repository") and [nebula-storage](https://github.com/vesoft-inc/nebula-storage "GitHub page of the nebula-storage repository") repositories. For example, to install 2.0.0 beta, run the following command.
+
+        ```bash
+        $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release \
+        --DNEBULA_COMMON_REPO_TAG=v2.0.0-beta -DNEBULA_STORAGE_REPO_TAG=v2.0.0-beta ..
+        ```
 
 5. Compile Nebula Graph.
 


### PR DESCRIPTION
The previous version of doc may lead to a mistake while the user tries to install a specific version like 2.0.0 beta. 
Added instructions to fix this problem.