### PR TITLE
Add note of BZip2 requirement for compiling Nebula Graph

### DIFF
--- a/docs-2.0/4.deployment-and-installation/1.resource-preparations.md
+++ b/docs-2.0/4.deployment-and-installation/1.resource-preparations.md
@@ -41,14 +41,15 @@ You must have the correct version of the software listed below to compile Nebula
 | readline-devel   | Any stable version | -                                                         |
 | ncurses-devel    | Any stable version | -                                                         |
 | zlid-devel       | Any stable version | -                                                         |
-| gcc              | 7.1.0 or above         | You can run `gcc -v` to check the gcc version.            |
+| gcc              | 7.1.0 or above     | You can run `gcc -v` to check the gcc version.            |
 | gcc-c++          | Any stable version | -                                                         |
-| cmake            | 3.5.0 or above         | You can run `cmake --version` to check the cmake version. |
+| cmake            | 3.5.0 or above     | You can run `cmake --version` to check the cmake version. |
 | gettext          | Any stable version | -                                                         |
 | curl             | Any stable version | -                                                         |
 | redhat-lsb-core  | Any stable version | -                                                         |
 | libstdc++-static | Any stable version | Only needed in CentOS 8+, RedHat 8+, and Fedora systems.  |
 | libasan          | Any stable version | Only needed in CentOS 8+, RedHat 8+, and Fedora systems.  |
+| bzip2            | Any stable version | -                                                         |
 
 Other third-party software will be automatically downloaded and installed to the build directory at the configure (cmake) stage.
 

--- a/docs-2.0/4.deployment-and-installation/1.resource-preparations.md
+++ b/docs-2.0/4.deployment-and-installation/1.resource-preparations.md
@@ -77,7 +77,8 @@ This section guides you through the downloading and installation of software req
                          cmake \
                          gettext \
                          curl \
-                         redhat-lsb-core
+                         redhat-lsb-core \
+                         bzip2
         // For CentOS 8+, RedHat 8+, and Fedora, install libstdc++-static, libasan as well
         $ yum install -y libstdc++-static libasan
         ```


### PR DESCRIPTION
<!--Thanks for your contribution to Nebula Graph documentation. See [CONTRIBUTING](https://github.com/vesoft-inc/nebula-docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

close https://github.com/vesoft-inc/nebula-docs/issues/567

BZip2 is required for compiling Nebula Graph[1], but it is not listed in the software requirements document.
It is listed in the Chinese version. But the English version missed it.
https://docs.nebula-graph.com.cn/2.0.1/4.deployment-and-installation/1.resource-preparations/#_4

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:<!--Give links here-->
- Other reference link(s):<!--Give links here-->

