### PR TITLE
using XY branch naming for dockercompose

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,8 +84,8 @@ extra:
     branch: v2.6
     tag: v2.6.1
   dockercompose:
-    release: 2.6.0
-    branch: v2.6.0
+    release: 2.6
+    branch: v2.6
   common:
     release: 2.5.1
   dashboard:


### PR DESCRIPTION
same as https://github.com/vesoft-inc/nebula-docs-cn/pull/1436

- https://github.com/vesoft-inc/nebula-docker-compose/blob/v2.6/docker-compose.yaml
- Previously v2.6.0 was linked to v2.6.0 image, which is with issues on Docker Desktop 4.3.0+(due to issues with cgroupv2), now with the new XY branch naming policy, v2.6 will be linked to the latest 2.6.x images.