### PR TITLE
Support the tck format for the output of EXPLAIN

### DIFF
--- a/docs-2.0/3.ngql-guide/17.query-tuning-statements/1.explain-and-profile.md
+++ b/docs-2.0/3.ngql-guide/17.query-tuning-statements/1.explain-and-profile.md
@@ -17,18 +17,18 @@ For example, a `SHOW TAGS` statement is processed into two `actions` and assigne
 * `EXPLAIN`
 
     ```ngql
-    EXPLAIN [format= {"row" | "dot"}] <your_nGQL_statement>;
+    EXPLAIN [format= {"row" | "dot" | "tck"}] <your_nGQL_statement>;
     ```
 
 * `PROFILE`
 
     ```ngql
-    PROFILE [format= {"row" | "dot"}] <your_nGQL_statement>;
+    PROFILE [format= {"row" | "dot" | "tck"}] <your_nGQL_statement>;
     ```
 
 ## Output formats
 
-The output of an `EXPLAIN` or a `PROFILE` statement has two formats, the default `row` format and the `dot` format. You can use the `format` option to modify the output format. Omitting the `format` option indicates using the default `row` format.
+The output of an `EXPLAIN` or a `PROFILE` statement has three formats, the default `row` format , the `dot` format, the `tck` format. You can use the `format` option to modify the output format. Omitting the `format` option indicates using the default `row` format.
 
 ## The `row` format
 
@@ -114,3 +114,21 @@ Execution Plan
 The Graphviz graph transformed from the above DOT statement is as follows.
 
 ![Graphviz graph of EXPLAIN SHOW TAGS](https://docs-cdn.nebula-graph.com.cn/docs-2.0/3.ngql-guide/16.query-tuning-statements/explain-show-tags.png)
+
+## The `tck` format
+In nebula-console, you can use the `format="tck"` option to support specifying the tck format, so that the generated output can be used directly in tck feature files for testing.
+
+```ngql
+nebula> > profile format="tck" FETCH PROP ON player "player_1","player_2","player_3" yield properties(vertex).name as name, properties(vertex).age as age;
+
+| name         | age |
+| "Piter Park" | 24  |
+| "aaa"        | 24  |
+| "ccc"        | 24  |
+
+Got 3 rows (time spent 1.784ms/2.298714ms)
+
+Execution Plan (optimize time 46 us)
+
+
+```

--- a/docs-2.0/3.ngql-guide/17.query-tuning-statements/1.explain-and-profile.md
+++ b/docs-2.0/3.ngql-guide/17.query-tuning-statements/1.explain-and-profile.md
@@ -116,19 +116,37 @@ The Graphviz graph transformed from the above DOT statement is as follows.
 ![Graphviz graph of EXPLAIN SHOW TAGS](https://docs-cdn.nebula-graph.com.cn/docs-2.0/3.ngql-guide/16.query-tuning-statements/explain-show-tags.png)
 
 ## The `tck` format
-In nebula-console, you can use the `format="tck"` option to support specifying the tck format, so that the generated output can be used directly in tck feature files for testing.
 
-```ngql
-nebula> > profile format="tck" FETCH PROP ON player "player_1","player_2","player_3" yield properties(vertex).name as name, properties(vertex).age as age;
+The tck format is similar to a table, but without borders and dividing lines between rows. Users can use the results as test cases in unit testing. 
+For information on tck format test cases, please refer to: https://github.com/vesoft-inc/nebula-graph/tree/master/tests#how-to-add-test-case.
 
-| name         | age |
-| "Piter Park" | 24  |
-| "aaa"        | 24  |
-| "ccc"        | 24  |
+- `EXPLAIN`
 
-Got 3 rows (time spent 1.784ms/2.298714ms)
+    ```ngql
+    nebula> EXPLAIN format="tck" FETCH PROP ON player "player_1","player_2","player_3" yield properties(vertex).name as name, properties(vertex).age as age;
+    Execution succeeded (time spent 261µs/613.718µs)
+    Execution Plan (optimize time 28 us)
+    | id | name        | dependencies | profiling data | operator info |
+    |  2 | Project     | 1            |                |               |
+    |  1 | GetVertices | 0            |                |               |
+    |  0 | Start       |              |                |               |
+                                                          
+    Wed, 22 Mar 2023 23:15:52 CST
+    ```
 
-Execution Plan (optimize time 46 us)
+- `PROFILE`
 
-
-```
+    ```ngql
+    nebula> PROFILE format="tck" FETCH PROP ON player "player_1","player_2","player_3" yield properties(vertex).name as name, properties(vertex).age as age;
+    | name         | age |
+    | "Piter Park" | 24  |
+    | "aaa"        | 24  |
+    | "ccc"        | 24  |
+    Got 3 rows (time spent 1.474ms/2.19677ms)
+    Execution Plan (optimize time 41 us)
+    | id | name        | dependencies | profiling data                                                                                                      | operator info |
+    |  2 | Project     | 1            | {"rows":3,"version":0}                                                                                              |               |
+    |  1 | GetVertices | 0            | {"resp[0]":{"exec":"232(us)","host":"127.0.0.1:9779","total":"758(us)"},"rows":3,"total_rpc":"875(us)","version":0} |               |
+    |  0 | Start       |              | {"rows":0,"version":0}                                                                                              |               |
+    Wed, 22 Mar 2023 23:16:13 CST
+    ```

--- a/docs-2.0/3.ngql-guide/17.query-tuning-statements/1.explain-and-profile.md
+++ b/docs-2.0/3.ngql-guide/17.query-tuning-statements/1.explain-and-profile.md
@@ -28,7 +28,7 @@ For example, a `SHOW TAGS` statement is processed into two `actions` and assigne
 
 ## Output formats
 
-The output of an `EXPLAIN` or a `PROFILE` statement has three formats, the default `row` format , the `dot` format, the `tck` format. You can use the `format` option to modify the output format. Omitting the `format` option indicates using the default `row` format.
+The output of an `EXPLAIN` or a `PROFILE` statement has three formats, the default `row` format, the `dot` format, and the `tck` format. You can use the `format` option to modify the output format. Omitting the `format` option indicates using the default `row` format.
 
 ## The `row` format
 
@@ -117,13 +117,13 @@ The Graphviz graph transformed from the above DOT statement is as follows.
 
 ## The `tck` format
 
-The tck format is similar to a table, but without borders and dividing lines between rows. Users can use the results as test cases in unit testing. 
-For information on tck format test cases, please refer to: https://github.com/vesoft-inc/nebula-graph/tree/master/tests#how-to-add-test-case.
+The tck format is similar to a table, but without borders and dividing lines between rows. You can use the results as test cases for unit testing. 
+For information on tck format test cases, see [TCK cases](https://github.com/vesoft-inc/nebula/tree/master/tests/tck/features).
 
 - `EXPLAIN`
 
     ```ngql
-    nebula> EXPLAIN format="tck" FETCH PROP ON player "player_1","player_2","player_3" yield properties(vertex).name as name, properties(vertex).age as age;
+    nebula> EXPLAIN format="tck" FETCH PROP ON player "player_1","player_2","player_3" YIELD properties(vertex).name as name, properties(vertex).age as age;
     Execution succeeded (time spent 261µs/613.718µs)
     Execution Plan (optimize time 28 us)
     | id | name        | dependencies | profiling data | operator info |
@@ -137,7 +137,7 @@ For information on tck format test cases, please refer to: https://github.com/ve
 - `PROFILE`
 
     ```ngql
-    nebula> PROFILE format="tck" FETCH PROP ON player "player_1","player_2","player_3" yield properties(vertex).name as name, properties(vertex).age as age;
+    nebula> PROFILE format="tck" FETCH PROP ON player "player_1","player_2","player_3" YIELD properties(vertex).name as name, properties(vertex).age as age;
     | name         | age |
     | "Piter Park" | 24  |
     | "aaa"        | 24  |


### PR DESCRIPTION
<!--Thanks for your contribution to NebulaGraph documentation. See [CONTRIBUTING](https://github.com/vesoft-inc/nebula-docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)
In the documentation for the explain and profile statements, add a section on the `tck` format

### What is the related PR or file link(s)?
related link:
- the pr link of nebula repo: https://github.com/vesoft-inc/nebula/pull/5414
- the pr link of nebula-console: https://github.com/vesoft-inc/nebula-console/pull/210
- the pr link of nebula nebula-go:https://github.com/vesoft-inc/nebula-go/pull/265
- the pr link of nebula-doc:https://github.com/vesoft-inc/nebula-docs/pull/2017
- the pr link of nebula-doc-cn:https://github.com/vesoft-inc/nebula-docs-cn/pull/2664

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:<!--Give links here-->
https://github.com/vesoft-inc/nebula-docs-cn/pull/2664
- Other reference link(s):<!--Give links here-->
issue line: https://github.com/vesoft-inc/nebula/issues/5274

