### PR TITLE
fixed missing installation step

### DIFF
--- a/docs-2.0/nebula-operator/3.deploy-nebula-graph-cluster/3.2create-cluster-with-helm.md
+++ b/docs-2.0/nebula-operator/3.deploy-nebula-graph-cluster/3.2create-cluster-with-helm.md
@@ -60,6 +60,8 @@
   - `DOCKER_USER`: The username for the image repository.
   - `DOCKER_PASSWORD`: The password for the image repository.
 
+  {{ent.ent_end}}
+
 6. Apply the variables to the Helm chart to create a NebulaGraph cluster.
 
   ```bash


### PR DESCRIPTION
<!--Thanks for your contribution to NebulaGraph documentation. See [CONTRIBUTING](https://github.com/vesoft-inc/nebula-docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

The installation step in the [rendered version](https://docs.nebula-graph.io/3.6.0/nebula-operator/3.deploy-nebula-graph-cluster/3.2create-cluster-with-helm/) of the doc is missing. Looking at the raw file, it seemed someone has missed closing the enterprise edition area. 
