### PR TITLE
fix the display of latex formula

### DIFF
--- a/docs-2.0-en/14.client/3.nebula-cpp-client.md
+++ b/docs-2.0-en/14.client/3.nebula-cpp-client.md
@@ -63,7 +63,7 @@ This document describes how to install NebulaGraph CPP with the source code.
 
 5. Compile NebulaGraph CPP.
 
-  To speed up the compiling, use the `-j` option to set a concurrent number `N`. It should be $\min(\text{CPU}core number,\frac{the_memory_size(GB)}{2})$.
+  To speed up the compiling, use the `-j` option to set a concurrent number `N`. It should be $\min(\text{CPU core number},\frac{\text{the memory size(GB)}}{2})$.
 
   ```bash
   $ make -j{N}

--- a/docs-2.0-en/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
+++ b/docs-2.0-en/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
@@ -60,7 +60,7 @@ Installing NebulaGraph from the source code allows you to customize the compilin
 
         Check [Prepare resources for compiling, installing, and running NebulaGraph](../1.resource-preparations.md).
 
-    To speed up the compiling, use the `-j` option to set a concurrent number `N`. It should be $\min(\text{CPU}core number,\frac{the_memory_size(GB)}{2})$.
+    To speed up the compiling, use the `-j` option to set a concurrent number `N`. It should be $\min(\text{CPU core number},\frac{\text{the memory size(GB)}}{2})$.
 
   ```bash
   $ make -j{N} # E.g., make -j2


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Just a minor latex fix.

Before:

$\min(\text{CPU}core number,\frac{the_memory_size(GB)}{2})$

After:

$\min(\text{CPU core number},\frac{\text{the memory size(GB)}}{2})$