### PR TITLE
fix：Update 3.go.md&1.overview.md【zh&en】

### DIFF
--- a/docs-2.0-en/3.ngql-guide/1.nGQL-overview/1.overview.md
+++ b/docs-2.0-en/3.ngql-guide/1.nGQL-overview/1.overview.md
@@ -50,7 +50,7 @@ For details of the symbols in nGQL syntax, see the following table:
 |  \|    | complete alternative elements |
 | ...    | may be repeated any number of times |
 
-For example, create vertices in nGQL syntax:
+For example, insert vertices in nGQL syntax:
 
 ```ngql
 INSERT VERTEX [IF NOT EXISTS] [tag_props, [tag_props] ...]
@@ -67,6 +67,7 @@ Example statement:
 
 ```ngql
 nebula> CREATE TAG IF NOT EXISTS player(name string, age int);
+nebula> INSERT VERTEX IF NOT EXISTS player(name,age) VALUES "player100":("Tim Duncan", 42);
 ```
 
 ## About openCypher compatibility

--- a/docs-2.0-en/3.ngql-guide/7.general-query-statements/3.go.md
+++ b/docs-2.0-en/3.ngql-guide/7.general-query-statements/3.go.md
@@ -218,30 +218,31 @@ nebula> MATCH (v)<-[e:follow]- (v2) WHERE id(v) == 'player100' \
 
 ```ngql
 # Return the friends of the player100 vertex and the teams that the friends belong to.
-nebula> GO FROM "player100" OVER follow REVERSELY \
-        YIELD src(edge) AS id | \
+nebula> GO FROM "player100" OVER follow \
+        YIELD dst(edge) AS id | \
         GO FROM $-.id OVER serve \
         WHERE properties($^).age > 20 \
-        YIELD properties($^).name AS FriendOf, properties($$).name AS Team;
+        YIELD properties($^).name AS Friend, properties($$).name AS Team;
 +---------------------+-----------------+
-| FriendOf            | Team            |
+| Friend              | Team            |
 +---------------------+-----------------+
-| "Boris Diaw"        | "Spurs"         |
-| "Boris Diaw"        | "Jazz"          |
-| "Boris Diaw"        | "Suns"          |
-...
+| "Tony Parker"       | "Spurs"         |
+| "Tony Parker"       | "Hornets"       |
+| "Manu Ginobili"     | "Spurs"         |
++---------------------+-----------------+
 
 # The following MATCH query has the same semantics as the previous GO query.
-nebula> MATCH (v)<-[e:follow]- (v2)-[e2:serve]->(v3)  \
+nebula> MATCH (v)-[e:follow]-> (v2)-[e2:serve]->(v3)  \
         WHERE id(v) == 'player100' \
+        AND properties(v2).age > 20 \
         RETURN v2.player.name AS FriendOf, v3.team.name AS Team;
 +---------------------+-----------------+
-| FriendOf            | Team            |
+| Friend              | Team            |
 +---------------------+-----------------+
-| "Boris Diaw"        | "Spurs"         |
-| "Boris Diaw"        | "Jazz"          |
-| "Boris Diaw"        | "Suns"          |
-...
+| "Tony Parker"       | "Spurs"         |
+| "Tony Parker"       | "Hornets"       |
+| "Manu Ginobili"     | "Spurs"         |
++---------------------+-----------------+
 ```
 
 ### To use `GROUP BY` to group the output

--- a/docs-2.0-en/3.ngql-guide/7.general-query-statements/3.go.md
+++ b/docs-2.0-en/3.ngql-guide/7.general-query-statements/3.go.md
@@ -235,7 +235,7 @@ nebula> GO FROM "player100" OVER follow \
 nebula> MATCH (v)-[e:follow]-> (v2)-[e2:serve]->(v3)  \
         WHERE id(v) == 'player100' \
         AND properties(v2).age > 20 \
-        RETURN v2.player.name AS FriendOf, v3.team.name AS Team;
+        RETURN v2.player.name AS Friend, v3.team.name AS Team;
 +---------------------+-----------------+
 | Friend              | Team            |
 +---------------------+-----------------+

--- a/docs-2.0-zh/3.ngql-guide/1.nGQL-overview/1.overview.md
+++ b/docs-2.0-zh/3.ngql-guide/1.nGQL-overview/1.overview.md
@@ -54,7 +54,7 @@ nGQL 是一个进行中的项目，会持续发布新特性和优化，因此可
 |  \|    | 所有可选的元素。 |
 | ...    | 可以重复多次。 |
 
-例如创建点的 nGQL 语法：
+例如插入一个点的 nGQL 语法：
 
 ```ngql
 INSERT VERTEX [IF NOT EXISTS] [tag_props, [tag_props] ...]
@@ -74,6 +74,7 @@ prop_value_list:
 
 ```ngql
 nebula> CREATE TAG IF NOT EXISTS player(name string, age int);
+nebula> INSERT VERTEX IF NOT EXISTS player(name,age) VALUES "player100":("Tim Duncan", 42);
 ```
 
 ## 关于 openCypher 兼容性

--- a/docs-2.0-zh/3.ngql-guide/7.general-query-statements/3.go.md
+++ b/docs-2.0-zh/3.ngql-guide/7.general-query-statements/3.go.md
@@ -215,28 +215,30 @@ nebula> MATCH (v)<-[e:follow]- (v2) WHERE id(v) == 'player100' \
 ```ngql
 # 查询 player100 年龄大于 20 的朋友和这些朋友所属队伍。
 nebula> GO FROM "player100" OVER follow \
-        YIELD src(edge) AS id | \
+        YIELD dst(edge) AS id | \
         GO FROM $-.id OVER serve \
         WHERE properties($^).age > 20 \
         YIELD properties($^).name AS Friend, properties($$).name AS Team;
 +---------------------+-----------------+
 | Friend              | Team            |
 +---------------------+-----------------+
-| "Tim Duncan"        | "Spurs"         |
-| "Tim Duncan"        | "Spurs"         |
+| "Tony Parker"       | "Spurs"         |
+| "Tony Parker"       | "Hornets"       |
+| "Manu Ginobili"     | "Spurs"         |
 +---------------------+-----------------+
 
 # 该 MATCH 查询与上一个 GO 查询具有相同的语义。
-nebula> MATCH (v)<-[e:follow]- (v2)-[e2:serve]->(v3)  \
+nebula> MATCH (v)-[e:follow]-> (v2)-[e2:serve]->(v3)  \
         WHERE id(v) == 'player100' \
+        AND properties(v2).age > 20 \
         RETURN v2.player.name AS FriendOf, v3.team.name AS Team;
 +---------------------+-----------------+
-| FriendOf            | Team            |
+| Friend              | Team            |
 +---------------------+-----------------+
-| "Boris Diaw"        | "Spurs"         |
-| "Boris Diaw"        | "Jazz"          |
-| "Boris Diaw"        | "Suns"          |
-...
+| "Tony Parker"       | "Spurs"         |
+| "Tony Parker"       | "Hornets"       |
+| "Manu Ginobili"     | "Spurs"         |
++---------------------+-----------------+
 ```
 
 ### 使用 GROUP BY 分组

--- a/docs-2.0-zh/3.ngql-guide/7.general-query-statements/3.go.md
+++ b/docs-2.0-zh/3.ngql-guide/7.general-query-statements/3.go.md
@@ -231,7 +231,7 @@ nebula> GO FROM "player100" OVER follow \
 nebula> MATCH (v)-[e:follow]-> (v2)-[e2:serve]->(v3)  \
         WHERE id(v) == 'player100' \
         AND properties(v2).age > 20 \
-        RETURN v2.player.name AS FriendOf, v3.team.name AS Team;
+        RETURN v2.player.name AS Friend, v3.team.name AS Team;
 +---------------------+-----------------+
 | Friend              | Team            |
 +---------------------+-----------------+


### PR DESCRIPTION
1、修改 _nGQL指南 -> nGQL概述 -> 占位标识符和占位符值_ 中nGQL语法和语句示例不一致的问题
![image](https://github.com/vesoft-inc/nebula-docs/assets/137484745/c6b74e4a-24c4-47a2-bbfe-289ff422f48f)

2、修改 _nGQL指南 -> 通用查询语句 -> GO -> 子查询作为起始点_ 中
①go查询方式，中文版可能是少了REVERSELY导致语句结果错误
②match查询方式少了age条件
修改方式：将go语句中src改为dst，将match语句中加上age条件且改变边的方向，两种方式保持边的方向一致且结果一致。
![image](https://github.com/vesoft-inc/nebula-docs/assets/137484745/2a1373fa-00fb-4e45-a84b-188dd5e0c8bd)
