### PR TITLE
Update nebula.release version to release-3.8

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -279,7 +279,7 @@ extra:
     master: master
     base20: 2.0
     base200: 2.0.0
-    branch: release-3.6
+    branch: release-3.8
     tag: v3.8.0
     name: NebulaGraph
   studio:


### PR DESCRIPTION
<!--Thanks for your contribution to NebulaGraph documentation. See [CONTRIBUTING](https://github.com/vesoft-inc/nebula-docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

This PR fixes an inconsistency in the `mkdocs.yml` file.  
The current `branch` is set to `release-3.6`, while the `release` version is `3.8.0`.  
To ensure that users clone the correct version of NebulaGraph based on the documentation, this PR updates:

```diff
- branch: release-3.6
+ branch: release-3.8
```

You can refer to the screenshot below showing that the release is 3.8.0 but the branch used is still release-3.6:

<img width="1793" height="460" alt="Snipaste_2025-08-05_16-06-48" src="https://github.com/user-attachments/assets/fb0bca5d-d76e-431c-91ee-1d4484d8126b" />
