### PR TITLE
Fix v3.5.0 polyfill and docs deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,14 +9,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # fetch all commits/branches for gitversion
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           architecture: 'x64'
 
       - name : prepare

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,7 +130,6 @@ extra_javascript:
   - js/search.js
   - js/config.js
   - js/version-select.js  
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - js/hotjar.js
   - https://www-cdn.nebula-graph.io/nebula-docs/nebula-docs.7e772ed81c779cacbefc.js

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ weasyprint
 mkdocs-material-extensions
 mike==1.1.2
 mkdocs-material==9.4.6
-mkdocs-material-extensions
 mkdocs-macros-plugin
 mdx_truly_sane_lists
 mkdocs_latest_release_plugin


### PR DESCRIPTION
## Summary
- remove the polyfill.io script from the documentation
- update actions/checkout from v2 to v4
- update actions/setup-python from v1 to v5
- use Python 3.10 instead of the unavailable Python 3.8 runner image
- remove the duplicate mkdocs-material-extensions requirement

## Verification
- dependency installation completed successfully
- mkdocs build completed successfully for 352 documents
- confirmed polyfill.io is absent from mkdocs.yml
- workflow YAML syntax and git diff --check passed