### PR TITLE
Fix v3.2.0 polyfill and docs deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,14 +8,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1 # fetch all commits/branches for gitversion
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           architecture: 'x64'
 
       - name : prepare

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,7 +113,6 @@ extra_javascript:
   - js/search.js
   - js/config.js
   - js/version-select.js  
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - js/hotjar.js
 


### PR DESCRIPTION
## Summary
- remove the polyfill.io script from the documentation
- update actions/checkout from v2 to v4
- update actions/setup-python from v1 to v5
- use Python 3.10 and the ubuntu-latest runner

## Verification
- confirmed polyfill.io is absent from mkdocs.yml
- confirmed the workflow uses checkout v4, setup-python v5, and Python 3.10
- git diff --check passed