### PR TITLE
Fix v3.5.0 docs dependency compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
 mkdocs
 weasyprint==54.3
+pydyf==0.1.2
 mkdocs-material-extensions
 mike==1.1.2
 mkdocs-material==9.4.6
-mkdocs-macros-plugin
+mkdocs-material-extensions
+mkdocs-macros-plugin==1.4.0
 mdx_truly_sane_lists
 mkdocs_latest_release_plugin
-mkdocs-git-revision-date-localized-plugin
+mkdocs-git-revision-date-localized-plugin==1.3.0
 mkdocs-with-pdf
 qrcode
 mkdocs-exclude


### PR DESCRIPTION
## Summary
- align requirements.txt with the deployment-tested v3.5.1 dependency set
- pin WeasyPrint 54.3 with pydyf 0.1.2
- pin mkdocs-macros-plugin 1.4.0 and mkdocs-git-revision-date-localized-plugin 1.3.0
- fix the pydyf transform API incompatibility exposed by the Python 3.10 workflow update

## Verification
- requirements.txt exactly matches v3.5.1
- v3.5.1 GitHub Pages deployment completed successfully with this dependency set
- full v3.0.0 HTML/PDF build completed successfully (273 documents)
- git diff --check passed