### PR TITLE
fix: make v3.0.2 docs deployment resilient

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           # mike delete v3.0.2 -p
           for attempt in 1 2 3; do
             git fetch origin gh-pages
-            if mike deploy 3.0.2 --rebase -p; then
+            if mike --rebase deploy 3.0.2 -p; then
               mike list
               exit 0
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,10 +38,19 @@ jobs:
       - name: Mike Deploy 3.0.2
         run: |
           # mike delete v3.0.2 -p
-          git fetch origin gh-pages --depth=1 # fix mike's CI update
-          mkdocs build -v # this is a test
-          mike deploy 3.0.2 -p 
-          mike list
+          for attempt in 1 2 3; do
+            git fetch origin gh-pages
+            if mike deploy 3.0.2 --rebase -p; then
+              mike list
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+
+            sleep $((attempt * 30))
+          done
 
       # - name: Deploy
       #   uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Summary
- remove the redundant standalone MkDocs build before `mike deploy`
- fetch the full current `gh-pages` history and rebase the local deployment branch
- retry deployment up to three times when another version updates `gh-pages` concurrently

## Context
The v3.0.2 deployment completed its HTML/PDF build but failed to push because another version updated `gh-pages` during the long build window.