### PR TITLE
fix: make v3.4.4 docs deployment resilient

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1 # fetch all commits/branches for gitversion
+          fetch-depth: 0 # fetch all commits/branches for gitversion
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -25,12 +25,22 @@ jobs:
       - name: Git Config
         run: git config user.name whitewum && git config user.email min.wu@vesoft.com
           
-      - name: Mike Deploy master
+      - name: Mike Deploy 3.4.4
         run: |
-          # mike delete master -p
-          git fetch origin gh-pages --depth=1 # fix mike's CI update
-          mike deploy 3.4.4 -p 
-          mike list
+          # mike delete 3.4.4 -p
+          for attempt in 1 2 3; do
+            git fetch origin gh-pages
+            if mike deploy 3.4.4 --rebase -p; then
+              mike list
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+
+            sleep $((attempt * 30))
+          done
 
       # - name: Deploy
       #   uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           # mike delete 3.4.4 -p
           for attempt in 1 2 3; do
             git fetch origin gh-pages
-            if mike deploy 3.4.4 --rebase -p; then
+            if mike --rebase deploy 3.4.4 -p; then
               mike list
               exit 0
             fi


### PR DESCRIPTION
## Summary
- fetch complete Git history for deployment
- sync and rebase on the latest `gh-pages` state before publishing
- retry deployment up to three times when another version updates `gh-pages` concurrently
- correct the deployment step name and version comment

## Context
The v3.4.4 site and PDF built successfully, but the final push was rejected because another workflow advanced the shared `gh-pages` branch.